### PR TITLE
SteerBot: add simple rover with car steering and rear wheel drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ and control the 6 wheel motors and 4 steering servos.
 
 This is a Gazebo model of a Quadruped robot developed by Ashvath in this project: [GSoC 2020: Walking Robot Support For Ardupilot](https://discuss.ardupilot.org/t/gsoc-2020-walking-robot-support-for-ardupilot/57080).
 
-The controller for this model also uses the ArduPilot Lua scripting framewortk.
+The servo mixer for this model uses the ArduPilot Lua scripting framewortk.
+
+### SteerBot with ArduPilot
+
+This is a simple Gazebo model of a rover with car steering and rear wheel drive.
+
+The servo mixer for this model uses the ArduPilot Lua scripting framewortk.
 
 ## License
 

--- a/config/steer_bot/README.md
+++ b/config/steer_bot/README.md
@@ -1,10 +1,12 @@
 # SteerBot with ArduPilot
 
-This is a Gazebo model of a simple rover with Ackermann steering geometry integrated with ArduPilot. The model can be controlled with SITL using the standard rover configuration.
+This is a Gazebo model of a simple rover with Ackermann steering geometry integrated with ArduPilot.
 
 ## Running the simulation
 
-Set up the rover and SITL following the ArduPilot wiki instructions.
+The model requires a custom mixer for the servo outputs which is implemented using
+a Lua script available in the `./config/steer_bot/scripts` directory. SITL will
+need to be configured to use scripting: see the Ardupilot documentation [Lua Scripts](https://ardupilot.org/rover/docs/common-lua-scripts.html?highlight=lua#lua-scripts) for more detail.
 
 ### Start Gazebo
 
@@ -18,4 +20,66 @@ $ gazebo --verbose
 ```bash
 # start SITL using the JSON backend and save logs in the folder ./steer_bot
 $ sim_vehicle.py --vehicle Rover --frame JSON --aircraft=steer_bot --console --map
+```
+
+### Servo Mixer
+
+The servo mixer retrieves the yaw and throttle control outputs and calculates the
+steering angles for the front wheels and speed commands for the rear wheels.
+
+The rear wheels are both assigned the same speed commands (diff-locked) so the
+rear wheels will need to skid slightly when turning.
+
+The front wheels are not driven and only steer. The wheel angle is calculated
+by scaling the input steering command (yaw) between zero and the maximum steering
+angle (in this case 45 deg). This wheel angle is used to set the angle of the inside
+front wheel and determine the turning radius for the vehicle. The turning radius is then
+used to calculate the wheel angle of the outside front wheel.
+
+### Parameters
+
+Enable Lua scripting by setting `SCR_ENABLE = 1`, refresh parameters and restart. 
+
+A full parameter set for the rover is saved in `./config/steer_bot/params/steer_bot.parm`.
+The key parameters are:
+
+**Scripting**
+
+```bash
+# Enable scripting and you may need to increase the memory available
+SCR_ENABLE       1
+SCR_HEAP_SIZE    65536
+```
+
+**Servos**
+
+```bash
+# The first 4 servos are controlled by the Lua script
+SERVO1_FUNCTION  94
+SERVO1_MAX       2000
+SERVO1_MIN       1000
+SERVO1_TRIM      1500
+SERVO2_FUNCTION  95
+SERVO2_MAX       2000
+SERVO2_MIN       1000
+SERVO2_TRIM      1500
+SERVO3_FUNCTION  96
+SERVO3_MAX       2000
+SERVO3_MIN       1000
+SERVO3_TRIM      1500
+SERVO4_FUNCTION  97
+SERVO4_MAX       2000
+SERVO4_MIN       1000
+SERVO4_TRIM      1500
+```
+
+**RC**
+
+```bash
+RC1_MAX          2000
+RC1_MIN          1000
+RC1_TRIM         1500
+RC3_MAX          2000
+RC3_MIN          1000
+RC3_TRIM         1500
 ```

--- a/config/steer_bot/README.md
+++ b/config/steer_bot/README.md
@@ -1,0 +1,21 @@
+# SteerBot with ArduPilot
+
+This is a Gazebo model of a simple rover with Ackermann steering geometry integrated with ArduPilot. The model can be controlled with SITL using the standard rover configuration.
+
+## Running the simulation
+
+Set up the rover and SITL following the ArduPilot wiki instructions.
+
+### Start Gazebo
+
+```bash
+# start an empty world with containing the Quadruped
+$ gazebo --verbose 
+```
+
+### Start SITL
+
+```bash
+# start SITL using the JSON backend and save logs in the folder ./steer_bot
+$ sim_vehicle.py --vehicle Rover --frame JSON --aircraft=steer_bot --console --map
+```

--- a/config/steer_bot/scripts/steer_bot_mixer.lua
+++ b/config/steer_bot/scripts/steer_bot_mixer.lua
@@ -1,0 +1,363 @@
+--[[
+    Copyright (c) 2020, Rhys Mainwaring
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--]]
+
+--[[
+    Servo mixer for steer_bot rover
+
+    Vehicle control outputs are defined in AP_Vehicle::ControlOutput.
+
+        CONTROL_OUTPUT_THROTTLE = 3
+        CONTROL_OUTPUT_YAW = 4
+
+    The output directed to servos using the enum defined in SRV_Channel::Aux_servo_function_t.
+    For scripting the following parameters should be set:
+
+        SERVO1_FUNCTION = 94
+        SERVO2_FUNCTION = 95
+        SERVO3_FUNCTION = 96
+        SERVO4_FUNCTION = 97
+--]]
+
+-- control outputs
+local CONTROL_OUTPUT_THROTTLE = 3
+local CONTROL_OUTPUT_YAW = 4
+
+-- servo outputs
+local SERVO1_FUNCTION = 94      -- back_left_wheel_joint   (drive no steer)
+local SERVO2_FUNCTION = 95      -- back_right_wheel_joint  (drive no steer)
+local SERVO3_FUNCTION = 96      -- front_left_steer_joint  (steer no drive)
+local SERVO4_FUNCTION = 97      -- front_right_steer_joint (steer no drive)
+
+-- update at 50Hz
+local UPDATE_PERIOD = 20
+
+-- wheel geometry for rover (FRD), units are [m]
+local WHEEL_COORDS = {}
+WHEEL_COORDS[1] = { 0.0, -0.2}   -- back_left_wheel_joint
+WHEEL_COORDS[2] = { 0.0,  0.2}   -- back_right_wheel_joint
+WHEEL_COORDS[3] = { 0.4, -0.2}   -- front_left_steer_joint
+WHEEL_COORDS[4] = { 0.4,  0.2}   -- front_right_steer_joint
+
+local WHEEL_SEP_W = 0.4             -- rear wheel lateral separation
+local WHEEL_SEP_H = 0.4             -- front to back wheel separation
+local WHEEL_ANGLE_MAX_DEG = 45.0    -- steering angle limit
+
+--[[
+    Constrain a value to a range
+
+    Parameters
+    ==========
+    value : float
+        The value to constrain
+    min_value : float
+        The lower limit of the range
+    max_value : float
+        The upper limit of the range
+
+    Returns
+    =======
+    float
+        A value constrained to the range
+--]]
+local function constrain(value, min_value, max_value)
+    return math.max(math.min(value, max_value), min_value)
+end
+
+--[[
+    Scale each element of a 2d array
+
+    Parameters
+    ==========
+    vector : array
+        The input array
+    scale : float
+        A scalar value
+
+    Returns
+    =======
+    array
+        The scaled array
+--]]
+local function scale_vector2d(vector, scale)
+    local vector_out = {}
+    for i=1, #vector do
+        vector_out[i] = {vector[i][1] * scale, vector[i][2] * scale}
+    end
+    return vector_out
+end
+
+--[[
+    Calculate the Euclidean distance between two points
+
+    Parameters
+    ==========
+    a : array
+        The first point
+    b : array
+        The second point
+
+    Returns
+    =======
+    float
+        The distance (L2 norm) between the two points
+--]]
+local function distance_vector2d(a, b)
+    local dx = b[1] - a[1]
+    local dy = b[2] - a[2]
+    local r = math.sqrt(dx * dx + dy * dy)
+    return r
+end
+
+--[[
+    Rescale the wheel coordinates by the half the mid wheel separation
+
+    The saturation limits for steering and throttle control are calculated
+    in scaled coordinates assuming a wheel separation of 2.
+
+    Parameters
+    ==========
+    wheel_coords : array
+        The array of wheel coordinates (x, y)
+    wheel_sep_w : float
+        The lateral distance between the left and right non-steering wheels
+
+    Returns
+    =======
+    array
+        The scaled (normalised) wheel coordinates
+
+--]]
+local function normalise_wheel_coordinates(wheel_coords, wheel_sep_w)
+    return scale_vector2d(wheel_coords, 2.0 / wheel_sep_w)
+end
+
+--[[
+    Calculate a wheel's distance from the instantaneous centre of curvature
+
+    Parameters
+    ==========
+    icc : array
+        The coordinates (x, y) of the instantaneous centre of curvature
+    wheel_coords : array
+        The (x, y) normalised wheel coordinates
+
+    Returns
+    =======
+    float
+        The distance
+
+--]]
+local function wheel_turning_radius(icc, wheel_coord)
+    return distance_vector2d(icc,  wheel_coord)
+end
+
+--[[
+    Rescale an array or turning radii so the maximum no greater than 1
+
+    This function returns a normalised array of turning radii for the
+    wheels. It ensures that the servo outputs are constainined to [0, 1].
+    The radii are assumed positive.
+
+    Parameters
+    ==========
+    r : array
+        An array of turning radii (r[i] >= 0)
+
+    Returns
+    =======
+    array
+        The rescaled turning radii (array).
+--]]
+local function rescale_turning_radii(r)
+
+    -- determine maximum
+    local r_max = 0.0
+    for i = 1, #r do
+        if r[i] == math.huge then
+            r_max = math.huge
+            break
+        else
+            r_max = math.max(r_max, r[i])
+        end
+    end
+
+    -- rescale
+    local r_s = {}
+    for i = 1, #r do
+        if r_max == math.huge then
+            r_s[i] = 1.0
+        else
+            r_s[i] = r[i] / r_max
+        end
+    end
+
+    return r_s
+end
+
+--[[
+    Calculate the wheel angle for a turn about a given ICC
+
+    This function calculates the unconstrained steering angle for
+    a wheel given and instantaneous centre of curvature (ICC). The
+    output steering angle is in [-pi, pi]
+
+    Parameters
+    ==========
+    icc : array
+        An array (x, y) containing x and y coordinates of the ICC
+    wheel_coord : array
+        An array (x, y) containing x and y coordinates of a wheels axis
+
+    Returns
+    =======
+    float
+        The steering angle in radians. The angle is in [-pi, pi]
+--]]
+local function calc_wheel_angle(icc, wheel_coord)
+    local dx = icc[1] - wheel_coord[1]
+    local dy = icc[2] - wheel_coord[2]
+    local theta = math.atan(dx, dy)
+    return theta
+end
+
+--[[
+    Calculate the servo outputs for a rover from steering and throttle control
+
+    This function calculates the wheel speed and steering angle for the
+    drive wheels and steering servos on a rover. The servo outputs are
+    normalised to [-1, 1].
+
+    The steering angles are constrained [-WHEEL_ANGLE_MAX_DEG, WHEEL_ANGLE_MAX_DEG].
+
+    NB: in this version the rear drive wheels are diff-locked (i.e. both are given
+    the same throttle command)
+
+    Parameters
+    ==========
+    steering : float
+        The normalised steering rate in [-1, 1]
+    throttle : float
+        The normalised throttle in [-1, 1]
+
+    Returns
+    =======
+    wheels, steers : array, array
+        Return the normalised servo outputs for 4 wheels and 4 steers
+--]]
+local function servo_outputs(steering, throttle)
+    -- reverse steering when throttle reversed
+    if throttle < 0  then
+        steering = -steering
+    end
+
+    -- capture the sign of steering and throttle as main calc assumes steering, throttle > 0
+    local steering_sign = 1
+    if steering < 0 then
+        steering_sign = -1
+        steering = -steering
+    end
+
+    local wheels = {0.0, 0.0, 0.0, 0.0}
+    local steers = {0.0, 0.0, 0.0, 0.0}
+
+    -- instantaneous centre of curvature
+    local r = {0.0, 0.0, 0.0, 0.0}
+
+    -- calc steering
+    local wheel_angle_max_rad = math.rad(WHEEL_ANGLE_MAX_DEG)
+    local wheel_angle_rad = wheel_angle_max_rad * steering
+    local r_p = math.huge
+    if wheel_angle_rad > 0 then
+        r_p = WHEEL_SEP_H / math.tan(wheel_angle_rad) + WHEEL_SEP_W * 0.5
+    end
+    local icc = {0.0, r_p}
+
+    -- wheel speed and steering angles
+    for i = 1, #r do
+
+        -- calc throttle - all wheels driven at same speed
+        wheels[i] = throttle
+        
+        -- calc steering - angles specific to each wheel
+        steers[i] = calc_wheel_angle(icc, WHEEL_COORDS[i])
+
+        -- apply steering limits
+        steers[i] = constrain(steers[i], -wheel_angle_max_rad, wheel_angle_max_rad)
+
+        -- enforce constraints
+        wheels[i] = constrain(wheels[i], -1.0, 1.0)
+        steers[i] = constrain(steers[i], -1.0, 1.0)
+    end
+
+    -- flip wheel speeds and steering angles and signs if steering < 0
+    if steering_sign < 0 then
+        for i = 1, #steers/2 do
+            local tmp = wheels[2 * i - 1]
+            wheels[2 * i - 1] = wheels[2 * i]
+            wheels[2 * i] = tmp
+
+            tmp = steers[2 * i - 1]
+            steers[2 * i - 1] = -steers[2 * i]
+            steers[2 * i] = -tmp
+        end
+    end
+
+    -- debug output
+    --[[
+    gcs:send_text(6, string.format("STR:%.2f THR:%.2f RP:%.2f S[1]:%.2f, S[2]:%.2f S[2]:%.2f S[4]:%.2f",
+        steering, throttle, r_p, math.deg(steers[1]), math.deg(steers[2]), math.deg(steers[3]), math.deg(steers[4])))
+    --]]
+
+    return wheels, steers
+end
+
+--[[
+    Main update loop
+
+    Poll the control outputs every UPDATE_PERIOD milli seconds,
+    compute the servo outputs for wheels and steeing and send
+    them to the servo channels.
+--]]
+local function update()
+    -- retrieve high level steering and throttle control outputs
+    local steering = vehicle:get_control_output(CONTROL_OUTPUT_YAW)
+    local throttle = vehicle:get_control_output(CONTROL_OUTPUT_THROTTLE)
+
+    -- compute servo outputs
+    local wheels = {0.0, 0.0, 0.0, 0.0}
+    local steers = {0.0, 0.0, 0.0, 0.0}
+
+    wheels, steers = servo_outputs(steering, throttle)
+
+    -- always allow steering (the back two wheels do not steer)
+    SRV_Channels:set_output_norm(SERVO3_FUNCTION, steers[3])
+    SRV_Channels:set_output_norm(SERVO4_FUNCTION, steers[4])
+
+    -- wheel servos only set when armed
+    if not arming:is_armed() then
+        -- if not armed move throttle to mid
+        SRV_Channels:set_output_norm(SERVO1_FUNCTION, 0)
+        SRV_Channels:set_output_norm(SERVO2_FUNCTION, 0)
+    else
+        SRV_Channels:set_output_norm(SERVO1_FUNCTION, wheels[1])
+        SRV_Channels:set_output_norm(SERVO2_FUNCTION, wheels[2])
+    end
+
+    return update, UPDATE_PERIOD
+end
+
+gcs:send_text(6, "steer_bot_mixer.lua is running")
+return update(), 3000
+

--- a/models/steer_bot/model.config
+++ b/models/steer_bot/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<model>
+  <name>SteerBot</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Rhys Mainwaring</name>
+    <email>rhys.mainwaring@me.com</email>
+  </author>
+
+  <description>
+    A Gazebo model of a simple car with Ackermann steering 
+  </description>
+
+</model>

--- a/models/steer_bot/model.sdf
+++ b/models/steer_bot/model.sdf
@@ -1,0 +1,578 @@
+<?xml version="1.0" ?>
+<sdf version='1.7'>
+  <model name='steer_bot'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>5</mass>
+        <inertia>
+          <ixx>0.0416667</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.108333</iyy>
+          <iyz>0</iyz>
+          <izz>0.141667</izz>
+        </inertia>
+      </inertial>
+      <collision name='base_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.5 0.3 0.1</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='base_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.5 0.3 0.1</size>
+          </box>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Green</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='front_left_steer_joint' type='revolute'>
+      <pose relative_to='base_link'>0.2 0.2 0.12 0 -0 0</pose>
+      <parent>base_link</parent>
+      <child>front_left_steer_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-3.14159</lower>
+          <upper>3.14159</upper>
+          <effort>10</effort>
+          <velocity>5</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='front_left_steer_link'>
+      <pose relative_to='front_left_steer_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.000658333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.000658333</iyy>
+          <iyz>0</iyz>
+          <izz>0.00125</izz>
+        </inertia>
+      </inertial>
+      <collision name='front_left_steer_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.02</length>
+            <radius>0.05</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='front_left_steer_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.02</length>
+            <radius>0.05</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Blue</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='front_left_wheel_joint' type='revolute'>
+      <pose relative_to='front_left_steer_link'>0 0 -0.12 -1.5708 0 0</pose>
+      <parent>front_left_steer_link</parent>
+      <child>front_left_wheel_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='front_left_wheel_link'>
+      <pose relative_to='front_left_wheel_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.00303333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00303333</iyy>
+          <iyz>0</iyz>
+          <izz>0.005</izz>
+        </inertia>
+      </inertial>
+      <collision name='front_left_wheel_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='front_left_wheel_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Red</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='front_right_steer_joint' type='revolute'>
+      <pose relative_to='base_link'>0.2 -0.2 0.12 0 -0 0</pose>
+      <parent>base_link</parent>
+      <child>front_right_steer_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-3.14159</lower>
+          <upper>3.14159</upper>
+          <effort>10</effort>
+          <velocity>5</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='front_right_steer_link'>
+      <pose relative_to='front_right_steer_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.000658333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.000658333</iyy>
+          <iyz>0</iyz>
+          <izz>0.00125</izz>
+        </inertia>
+      </inertial>
+      <collision name='front_right_steer_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.02</length>
+            <radius>0.05</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='front_right_steer_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.02</length>
+            <radius>0.05</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Blue</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='front_right_wheel_joint' type='revolute'>
+      <pose relative_to='front_right_steer_link'>0 0 -0.12 -1.5708 0 0</pose>
+      <parent>front_right_steer_link</parent>
+      <child>front_right_wheel_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='front_right_wheel_link'>
+      <pose relative_to='front_right_wheel_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.00303333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00303333</iyy>
+          <iyz>0</iyz>
+          <izz>0.005</izz>
+        </inertia>
+      </inertial>
+      <collision name='front_right_wheel_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='front_right_wheel_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Red</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='front_steer_joint' type='revolute'>
+      <pose relative_to='base_link'>0.2 0 0.12 0 -0 0</pose>
+      <parent>base_link</parent>
+      <child>front_steer_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-3.14159</lower>
+          <upper>3.14159</upper>
+          <effort>10</effort>
+          <velocity>5</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='front_steer_link'>
+      <pose relative_to='front_steer_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.000658333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.000658333</iyy>
+          <iyz>0</iyz>
+          <izz>0.00125</izz>
+        </inertia>
+      </inertial>
+      <collision name='front_steer_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.02</length>
+            <radius>0.05</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='front_steer_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.02</length>
+            <radius>0.05</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Yellow</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rear_left_wheel_joint' type='revolute'>
+      <pose relative_to='base_link'>-0.2 0.2 0 -1.5708 0 0</pose>
+      <parent>base_link</parent>
+      <child>rear_left_wheel_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='rear_left_wheel_link'>
+      <pose relative_to='rear_left_wheel_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.00303333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00303333</iyy>
+          <iyz>0</iyz>
+          <izz>0.005</izz>
+        </inertia>
+      </inertial>
+      <collision name='rear_left_wheel_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rear_left_wheel_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Red</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rear_right_wheel_joint' type='revolute'>
+      <pose relative_to='base_link'>-0.2 -0.2 0 -1.5708 0 0</pose>
+      <parent>base_link</parent>
+      <child>rear_right_wheel_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='rear_right_wheel_link'>
+      <pose relative_to='rear_right_wheel_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.00303333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00303333</iyy>
+          <iyz>0</iyz>
+          <izz>0.005</izz>
+        </inertia>
+      </inertial>
+      <collision name='rear_right_wheel_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rear_right_wheel_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.08</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Red</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rear_wheel_joint' type='revolute'>
+      <pose relative_to='base_link'>-0.2 0 0 -1.5708 0 0</pose>
+      <parent>base_link</parent>
+      <child>rear_wheel_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='rear_wheel_link'>
+      <pose relative_to='rear_wheel_joint'>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>0.03125</mass>
+        <inertia>
+          <ixx>9.04948e-06</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>9.04948e-06</iyy>
+          <iyz>0</iyz>
+          <izz>9.76563e-06</izz>
+        </inertia>
+      </inertial>
+      <collision name='rear_wheel_link_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.04</length>
+            <radius>0.025</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rear_wheel_link_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.04</length>
+            <radius>0.025</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Yellow</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <static>0</static>
+  </model>
+</sdf>

--- a/models/steer_bot_ardupilot/model.config
+++ b/models/steer_bot_ardupilot/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<model>
+  <name>SteerBot with ArduPilot</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Rhys Mainwaring</name>
+    <email>rhys.mainwaring@me.com</email>
+  </author>
+
+  <description>
+    A Gazebo model of a simple car with ArduPilot integration 
+  </description>
+
+</model>

--- a/models/steer_bot_ardupilot/model.sdf
+++ b/models/steer_bot_ardupilot/model.sdf
@@ -1,0 +1,129 @@
+<?xml version='1.0'?>
+<sdf version='1.6'>
+<model name='steer_bot_ardupilot'>
+    <pose>0 0 0.21 0 0 0</pose>
+
+    <include>
+        <pose>0 0 0 0 0 0</pose>
+        <uri>model://steer_bot</uri>
+    </include>
+
+    <plugin name="ardupilot_plugin" filename="libArduPilotPlugin.so">
+        <!-- Port settings -->
+        <fdm_addr>127.0.0.1</fdm_addr>
+        <fdm_port_in>9002</fdm_port_in>
+        <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
+        <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
+        <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+
+        <!-- Sensors -->
+        <imuName>steer_bot_ardupilot::imu_link::imu_sensor</imuName>
+
+        <!-- Control / channels -->
+
+        <!--
+            SERVO1_FUNCTION 94 (Script 1)
+        -->
+        <control channel="0">
+            <jointName>steer_bot_ardupilot::steer_bot::front_left_steer_joint</jointName>
+            <useForce>1</useForce>
+            <multiplier>1.570796327</multiplier>
+            <offset>-0.5</offset>
+            <servo_min>1000</servo_min>
+            <servo_max>2000</servo_max>
+            <type>POSITION</type>
+            <p_gain>10</p_gain>
+            <i_gain>0</i_gain>
+            <d_gain>0</d_gain>
+            <i_max>1</i_max>
+            <i_min>0</i_min>
+            <cmd_max>0.785398163</cmd_max>
+            <cmd_min>-0.785398163</cmd_min>
+        </control>
+
+        <!--           
+            SERVO2_FUNCTION 95 (Script 2)
+        -->
+        <control channel="1">
+            <jointName>steer_bot_ardupilot::steer_bot::front_right_steer_joint</jointName>
+            <useForce>1</useForce>
+            <multiplier>1.570796327</multiplier>
+            <offset>-0.5</offset>
+            <servo_min>1000</servo_min>
+            <servo_max>2000</servo_max>
+            <type>POSITION</type>
+            <p_gain>10</p_gain>
+            <i_gain>0</i_gain>
+            <d_gain>0</d_gain>
+            <i_max>1</i_max>
+            <i_min>0</i_min>
+            <cmd_max>0.785398163</cmd_max>
+            <cmd_min>-0.785398163</cmd_min>
+        </control>
+
+        <!--           
+            SERVO3_FUNCTION 96 (Script 3)
+        -->
+        <control channel="2">
+            <jointName>steer_bot_ardupilot::steer_bot::rear_left_wheel_joint</jointName>
+            <useForce>1</useForce>
+            <multiplier>100.0</multiplier>
+            <offset>-0.5</offset>
+            <servo_min>1000</servo_min>
+            <servo_max>2000</servo_max>
+            <type>VELOCITY</type>
+            <p_gain>1</p_gain>
+            <i_gain>0</i_gain>
+            <d_gain>0</d_gain>
+            <i_max>1</i_max>
+            <i_min>0</i_min>
+            <cmd_max>50.0</cmd_max>
+            <cmd_min>-50.0</cmd_min>
+        </control>
+
+        <!--           
+            SERVO4_FUNCTION 97 (Script 4)
+        -->
+        <control channel="3">
+            <jointName>steer_bot_ardupilot::steer_bot::rear_right_wheel_joint</jointName>
+            <useForce>1</useForce>
+            <multiplier>100.0</multiplier>
+            <offset>-0.5</offset>
+            <servo_min>1000</servo_min>
+            <servo_max>2000</servo_max>
+            <type>VELOCITY</type>
+            <p_gain>1</p_gain>
+            <i_gain>0</i_gain>
+            <d_gain>0</d_gain>
+            <i_max>1</i_max>
+            <i_min>0</i_min>
+            <cmd_max>50.0</cmd_max>
+            <cmd_min>-50.0</cmd_min>
+        </control>
+    </plugin>
+
+    <link name='imu_link'>
+        <inertial>
+            <mass>0.01</mass>
+            <inertia>
+                <ixx>1.66667E-07</ixx>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyy>1.66667E-07</iyy>
+                <iyz>0</iyz>
+                <izz>1.66667E-07</izz>
+            </inertia>
+        </inertial>
+        <sensor name="imu_sensor" type="imu">
+            <pose>0 0 0 3.141593 0 0</pose>
+            <always_on>1</always_on>
+            <update_rate>1000.0</update_rate>
+        </sensor>
+    </link>
+
+    <joint name='imu_joint' type='fixed'>
+        <child>imu_link</child>
+        <parent>steer_bot_ardupilot::steer_bot::base_link</parent>
+    </joint>
+</model>
+</sdf>

--- a/models/steer_bot_ardupilot/model.sdf
+++ b/models/steer_bot_ardupilot/model.sdf
@@ -25,46 +25,6 @@
             SERVO1_FUNCTION 94 (Script 1)
         -->
         <control channel="0">
-            <jointName>steer_bot_ardupilot::steer_bot::front_left_steer_joint</jointName>
-            <useForce>1</useForce>
-            <multiplier>1.570796327</multiplier>
-            <offset>-0.5</offset>
-            <servo_min>1000</servo_min>
-            <servo_max>2000</servo_max>
-            <type>POSITION</type>
-            <p_gain>10</p_gain>
-            <i_gain>0</i_gain>
-            <d_gain>0</d_gain>
-            <i_max>1</i_max>
-            <i_min>0</i_min>
-            <cmd_max>0.785398163</cmd_max>
-            <cmd_min>-0.785398163</cmd_min>
-        </control>
-
-        <!--           
-            SERVO2_FUNCTION 95 (Script 2)
-        -->
-        <control channel="1">
-            <jointName>steer_bot_ardupilot::steer_bot::front_right_steer_joint</jointName>
-            <useForce>1</useForce>
-            <multiplier>1.570796327</multiplier>
-            <offset>-0.5</offset>
-            <servo_min>1000</servo_min>
-            <servo_max>2000</servo_max>
-            <type>POSITION</type>
-            <p_gain>10</p_gain>
-            <i_gain>0</i_gain>
-            <d_gain>0</d_gain>
-            <i_max>1</i_max>
-            <i_min>0</i_min>
-            <cmd_max>0.785398163</cmd_max>
-            <cmd_min>-0.785398163</cmd_min>
-        </control>
-
-        <!--           
-            SERVO3_FUNCTION 96 (Script 3)
-        -->
-        <control channel="2">
             <jointName>steer_bot_ardupilot::steer_bot::rear_left_wheel_joint</jointName>
             <useForce>1</useForce>
             <multiplier>100.0</multiplier>
@@ -82,9 +42,9 @@
         </control>
 
         <!--           
-            SERVO4_FUNCTION 97 (Script 4)
+            SERVO2_FUNCTION 95 (Script 2)
         -->
-        <control channel="3">
+        <control channel="1">
             <jointName>steer_bot_ardupilot::steer_bot::rear_right_wheel_joint</jointName>
             <useForce>1</useForce>
             <multiplier>100.0</multiplier>
@@ -100,6 +60,48 @@
             <cmd_max>50.0</cmd_max>
             <cmd_min>-50.0</cmd_min>
         </control>
+        
+        <!--           
+            SERVO3_FUNCTION 96 (Script 3)
+        -->
+        <control channel="2">
+            <jointName>steer_bot_ardupilot::steer_bot::front_left_steer_joint</jointName>
+            <useForce>1</useForce>
+            <multiplier>1.570796327</multiplier>
+            <offset>-0.5</offset>
+            <servo_min>1000</servo_min>
+            <servo_max>2000</servo_max>
+            <type>POSITION</type>
+            <p_gain>2.0</p_gain>
+            <i_gain>0</i_gain>
+            <d_gain>0.1</d_gain>
+            <i_max>1</i_max>
+            <i_min>0</i_min>
+            <cmd_max>0.785398163</cmd_max>
+            <cmd_min>-0.785398163</cmd_min>
+        </control>
+
+        <!--           
+            SERVO4_FUNCTION 97 (Script 4)
+        -->
+        <control channel="3">
+            <jointName>steer_bot_ardupilot::steer_bot::front_right_steer_joint</jointName>
+            <useForce>1</useForce>
+            <multiplier>1.570796327</multiplier>
+            <offset>-0.5</offset>
+            <servo_min>1000</servo_min>
+            <servo_max>2000</servo_max>
+            <type>POSITION</type>
+            <p_gain>2.0</p_gain>
+            <i_gain>0</i_gain>
+            <d_gain>0.1</d_gain>
+            <i_max>1</i_max>
+            <i_min>0</i_min>
+            <cmd_max>0.785398163</cmd_max>
+            <cmd_min>-0.785398163</cmd_min>
+        </control>
+
+
     </plugin>
 
     <link name='imu_link'>


### PR DESCRIPTION
This PR adds a simple Gazebo model for a rover with car style front steering (Ackermann steering) and a diff-locked rear wheel drive. The servo outputs are set by a custom mixer implemented using a Lua script.   